### PR TITLE
Fixed a Multitap linking bug. Added freq() to Multitap.

### DIFF
--- a/Gamma/Delay.h
+++ b/Gamma/Delay.h
@@ -134,7 +134,7 @@ public:
 	}
 	
 	/// Set a tap's delay length as a frequency
-	void freq(float length, unsigned tap){
+	void freq(float v, unsigned tap){
         	delay(1.f/length, tap);
     	}
 


### PR DESCRIPTION
When declaring Multitap as a pointer (i.e. Multitap<> *delay), an error was thrown during compilation. adding "this->" before mIpol() fixes it. I've also added in a freq() method for individual taps in Multitap.
