### PR TITLE
Fix compile on macOS 14.7.5

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -244,6 +244,14 @@ else ifeq ($(PLATFORM), macosx)
 		CPPFLAGS += -I/usr/local/include/
 	endif
 
+	# Needed to link to libraries installed through homebrew or by user
+	ifneq ($(wildcard /opt/homebrew/lib),)
+		LDFLAGS += -L/opt/homebrew/lib/
+	endif
+	ifneq ($(wildcard /opt/homebrew/include),)
+		CPPFLAGS += -I/opt/homebrew/include/
+	endif
+
 	LDFLAGS += -lstdc++
 	DLIB_EXT = dylib
 	DLIB_OPT = dynamiclib

--- a/examples/synthesis/pluckedString.cpp
+++ b/examples/synthesis/pluckedString.cpp
@@ -47,10 +47,10 @@ public:
 
 	Accum<> tmr{1./0.1};
 	PluckedString
-		pluck1{scl::freq("d6")},
-		pluck2{scl::freq("g5")},
-		pluck3{scl::freq("a4")},
-		pluck4{scl::freq("d3")};
+		pluck1{static_cast<float>(scl::freq("d6"))},
+		pluck2{static_cast<float>(scl::freq("g5"))},
+		pluck3{static_cast<float>(scl::freq("a4"))},
+		pluck4{static_cast<float>(scl::freq("d3"))};
 
 	void onAudio(AudioIOData& io){
 


### PR DESCRIPTION

I tried to show students Gamma today, but it would not compile.

As of Feburary 2021 Hombrew installs stuff under `/opt/homebrew`. Macports has become the less popular package manager. 